### PR TITLE
Update goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,10 @@ builds:
       - amd64
     ldflags:
       - -buildmode=exe
-      - "{{ .Env.LDFLAGS }}"
+      - -s -w
+        -X "github.com/viveksahu26/url_shortner/buildversion.BuildVersion={{.Version}}"
+        -X "github.com/viveksahu26/url_shortner/buildversion.BuildTime={{time "2006-01-02T15:04:05Z07:00"}}"
+        -X "github.com/viveksahu26/url_shortner/buildversion.BuildCommit={{.FullCommit}}"
     binary: url_shortner-windows-{{ .Arch }}
     main: ./main.go
     no_unique_dist_dir: true
@@ -49,3 +52,9 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,13 +16,16 @@ sboms:
   - artifacts: binary
 
 builds:
-  - id: url_shortner
+  - id: linux-amd64
     env:
       - CGO_ENABLED=0
     goos:
       - linux
     goarch:
       - amd64
+    binary: url_shortner-linux-{{ .Arch }}
+    main: ./main.go
+    
 
 archives:
   - format: binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,20 @@ builds:
       - amd64
     binary: url_shortner-linux-{{ .Arch }}
     main: ./main.go
-    
+    no_unique_dist_dir: true
+
+  - id: windows-amd64
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -buildmode=exe
+      - "{{ .Env.LDFLAGS }}"
+    binary: url_shortner-windows-{{ .Arch }}
+    main: ./main.go
+    no_unique_dist_dir: true
+
 
 archives:
   - format: binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,3 +58,19 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+nfpms:
+  - id: url_shortner
+    package_name: url_shortner
+    file_name_template: "{{ .ConventionalFileName }}"
+    vendor: viveksahu26
+    homepage: https://github.com/viveksahu26/
+    maintainer: viveksahu26
+    builds:
+      - linux
+    description: It primarily used for converting long URL into short
+    license: "Apache License 2.0"
+    formats:
+      - apk
+      - deb
+      - rpm


### PR DESCRIPTION
Add native packages for installs of url_shortner packages. On build systems like AWS CodeBuild and others, instead of having users install Golang and then cosign or curl releases from GitHub, it would be helpful to install packages with the native package managers.